### PR TITLE
(fix): user page caching fixed

### DIFF
--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -3,7 +3,7 @@ import { useMutation } from '@apollo/client'
 import { useModalContext } from '../context/modal/ModalContext'
 import { useDarkModeContext } from '../context/dark-mode/DarkModeContext'
 import { ADD_USER, UPDATE_USER } from '../mutations/userMutations'
-import { GET_USERS } from '../queries/UserQueries'
+import { GET_USER, GET_USERS } from '../queries/UserQueries'
 import TextField from '@mui/material/TextField'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
@@ -17,8 +17,8 @@ const FormModal = () => {
 
   const {
     open,
-    editForm,
-    editUser,
+    editMode,
+    currentUser,
     addNewUser,
     updateExistingUser,
     closeModal,
@@ -35,10 +35,10 @@ const FormModal = () => {
   })
 
   useEffect(() => {
-    if (editForm) {
-      setData(editUser)
+    if (editMode) {
+      setData(currentUser)
     }
-  }, [editForm, editUser])
+  }, [editMode, currentUser])
 
   const { firstName, lastName, email, occupation, phoneNumber } = data
 
@@ -59,24 +59,16 @@ const FormModal = () => {
 
   const [updateUser] = useMutation(UPDATE_USER, {
     variables: {
-      id: editUser?.id,
+      id: currentUser?.id,
       firstName,
       lastName,
       email,
       occupation,
       phoneNumber,
     },
-    update(cache) {
-      const { users } = cache.readQuery({
-        query: GET_USERS,
-      })
-      cache.writeQuery({
-        query: GET_USERS,
-        data: {
-          users: users,
-        },
-      })
-    },
+    refetchQueries: [
+      { query: GET_USER, variables: { slug: currentUser?.slug } },
+    ],
   })
 
   const onChange = (e) => {
@@ -95,7 +87,7 @@ const FormModal = () => {
   }
 
   const onClose = () => {
-    closeModal(editForm, setErrorInput, setData)
+    closeModal(editMode, setErrorInput, setData)
   }
 
   return (
@@ -122,7 +114,6 @@ const FormModal = () => {
               Create new user
             </Typography>
           </Box>
-
           <TextField
             className='modal-inputs'
             id='outlined-basic'
@@ -184,7 +175,7 @@ const FormModal = () => {
             required
             error={errorInput && phoneNumber === ''}
           />
-          {editForm ? (
+          {editMode ? (
             <Button
               className='modal-update-button'
               variant='contained'

--- a/frontend/src/context/modal/ModalProvider.js
+++ b/frontend/src/context/modal/ModalProvider.js
@@ -62,6 +62,7 @@ const ModalProvider = ({ children }) => {
         email: user.email,
         occupation: user.occupation,
         phoneNumber: user.phoneNumber,
+        slug: user.slug,
       },
     })
   }
@@ -101,8 +102,8 @@ const ModalProvider = ({ children }) => {
   }
 
   //Close Modal
-  const closeModal = (editForm, setErrorInput, setData) => {
-    if (editForm) {
+  const closeModal = (editMode, setErrorInput, setData) => {
+    if (editMode) {
       dispatch({ type: CLOSE_EDIT_FORM })
     } else {
       dispatch({ type: CLOSE_MODAL })
@@ -122,8 +123,8 @@ const ModalProvider = ({ children }) => {
     <ModalContext.Provider
       value={{
         open: state.open,
-        editForm: state.editForm,
-        editUser: state.editUser,
+        editMode: state.editMode,
+        currentUser: state.currentUser,
         dispatch,
         addNewUser,
         populateEditForm,

--- a/frontend/src/context/modal/ModalReducer.js
+++ b/frontend/src/context/modal/ModalReducer.js
@@ -19,15 +19,15 @@ const ModalReducer = (state, action) => {
     case OPEN_EDIT_FORM: {
       return {
         open: true,
-        editForm: true,
-        editUser: action.payload,
+        editMode: true,
+        currentUser: action.payload,
       }
     }
     case CLOSE_EDIT_FORM: {
       return {
         open: false,
-        editForm: false,
-        editUser: {},
+        editMode: false,
+        currentUser: {},
       }
     }
     default:

--- a/frontend/src/context/modal/ModalState.js
+++ b/frontend/src/context/modal/ModalState.js
@@ -1,7 +1,7 @@
 const initialState = {
   open: false,
-  editForm: false,
-  editUser: {},
+  editMode: false,
+  currentUser: {},
 }
 
 export default initialState


### PR DESCRIPTION
- user page caching problem fixed: If user's page is visited before user is updated, and visited again after that, the new **updatedAt** timestamp will be displayed without the need to reload the page
- **Modal**, **ModalProvider**, **ModalState** and **ModalReducer** are refactored